### PR TITLE
maybe closer...

### DIFF
--- a/app/templates/components/d3-graph.hbs
+++ b/app/templates/components/d3-graph.hbs
@@ -1,7 +1,3 @@
 {{#if d3el}}
-  {{invoke callback d3el}}
-  {{#if on-enter}}
-    {{log 'called'}}
-    {{invoke (pipe (d3-enter on-enter)) d3el}}
-   {{/if}}
+  {{yield (invoke callback d3el)}}
 {{/if}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,11 +1,12 @@
-{{d3-graph 
-  (pipe 
-    (d3-select-all 'circle') 
+{{#d3-graph
+  (pipe
+    (d3-select-all 'circle')
     (d3-data (get data '[]'))
-  )
-  on-enter=(pipe (d3-append 'circle') (d3-attr cx=getXCoord cy=getYCoord r=getCircleRadius) (d3-on 'click' (action 'removeCircle'))
-  on-exit=(pipe (d3-remove))
+  ) as |data|
 }}
+  {{invoke (pipe d3-enter (d3-append 'circle')) data}}
+  {{invoke (pipe d3-exit d3-remove) data}}
+{{/d3-graph}}
 
 {{input value=radius}}
 <button {{action 'addCircle' radius}}>Add Circle</button>


### PR DESCRIPTION
wondering if this pattern is getting closer to what we need (it doesn't work yet)

but I see that we need to return a selection that we then use for `enter` and `exit`, like `circle` here:
```
var circle = svg.selectAll("circle")
    .data(data);

circle.exit().remove();

circle.enter().append("circle")
    .attr("r", 2.5);

circle
    .attr("cx", function(d) { return d.x; })
    .attr("cy", function(d) { return d.y; });